### PR TITLE
Fix for installing netscaler-api from a pip requirements file

### DIFF
--- a/netscaler.py
+++ b/netscaler.py
@@ -15,7 +15,6 @@ controller, utilizing the SOAP API to execute commands.
 """
 
 __author__ = 'Jathan McCollum <jathan+bitbucket@gmail.com>'
-__version__ = '0.2.1'
 
 import logging
 from suds.client import Client, WebFault

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ except ImportError:
 import os
 import sys
 
-from netscaler import __version__
-
 if sys.version_info[:2] < (2, 4):
     print "This package requires Python 2.4+. Sorry!"
     sys.exit(-11)
@@ -27,7 +25,7 @@ class CleanCommand(Command):
 
 setup(
     name = 'netscaler-api',
-    version = __version__,
+    version = '0.2.1',
     url = 'http://bitbucket.org/jathanism/netscaler-api/',
     download_url = 'http://bitbucket.org/jathanism/netscaler-api/downloads/',
     license = 'BSD',


### PR DESCRIPTION
Hi Jathan,

I ran into an issue installing netscaler-api via pip when using a requirements file.  For example:

(test) $ cat requirements.txt
suds==0.4
netscaler-api==0.2.0
(test) $ pip install -r requirements.txt 
Downloading/unpacking suds==0.4 (from -r requirements.txt (line 1))
  Downloading suds-0.4.tar.gz (104Kb): 104Kb downloaded
  Running setup.py egg_info for package suds
Downloading/unpacking netscaler-api==0.2.0 (from -r requirements.txt (line 2))
  Downloading netscaler-api-0.2.tar.gz
  Running setup.py egg_info for package netscaler-api
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/tmp/test/build/netscaler-api/setup.py", line 11, in <module>
        from netscaler import **version**
      File "netscaler.py", line 23, in <module>
        from suds.client import Client, WebFault
    ImportError: No module named suds.client
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/tmp/test/build/netscaler-api/setup.py", line 11, in <module>

```
from netscaler import __version__
```

  File "netscaler.py", line 23, in <module>

```
from suds.client import Client, WebFault
```

ImportError: No module named suds.client

The issue seems to be that pip does not fully install the packages until all packages have been successfully installed.  Thus, suds cannot be imported during the setup.py process.  This small commit changes the project so that suds is not imported during the running of setup.py.

Could you pull it?

Thanks!

David
